### PR TITLE
feat: 그룹 상세 조회 path storeId 추가

### DIFF
--- a/src/main/java/com/jangburich/domain/team/application/TeamService.java
+++ b/src/main/java/com/jangburich/domain/team/application/TeamService.java
@@ -1,9 +1,10 @@
 package com.jangburich.domain.team.application;
 
+import com.jangburich.domain.store.domain.Store;
+import com.jangburich.domain.store.repository.StoreRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,6 +39,7 @@ public class TeamService {
 	private final TeamRepository teamRepository;
 	private final UserRepository userRepository;
 	private final UserTeamRepository userTeamRepository;
+	private final StoreRepository storeRepository;
 
 	@Transactional
 	public TeamSecretCodeResponse registerTeam(String userId, RegisterTeamRequest registerTeamRequest) {
@@ -128,22 +130,25 @@ public class TeamService {
 		return myTeamResponses;
 	}
 
-	public MyTeamDetailsResponse getTeamDetailsById(String userId, Long teamId) {
+	public MyTeamDetailsResponse getTeamDetailsById(String userId, Long teamId, Long storeId) {
 		User user = userRepository.findByProviderId(userId)
 			.orElseThrow(() -> new NullPointerException("사용자를 찾을 수 없습니다."));
 
 		Team team = teamRepository.findById(teamId)
 			.orElseThrow(() -> new IllegalArgumentException("해당 팀을 찾을 수 없습니다."));
 
+		Store store = storeRepository.findById(storeId)
+				.orElseThrow(() -> new IllegalArgumentException("해당 가게를 찾을 수 없습니다."));
+
 		if (!team.getTeamLeader().getUser_id().equals(user.getUserId())) {
 			// 일반 구성원
 			return teamRepository.findMyTeamDetailsAsMember(user.getUserId(),
-				teamId);
+				teamId, storeId);
 		}
 		// 팀 리더일 때
 
 		return teamRepository.findMyTeamDetailsAsLeader(user.getUserId(),
-			teamId);
+			teamId, storeId);
 	}
 
 	public List<TeamMemberResponse> getTeamMembers(String userId, Long teamId) {

--- a/src/main/java/com/jangburich/domain/team/domain/repository/TeamQueryDslRepository.java
+++ b/src/main/java/com/jangburich/domain/team/domain/repository/TeamQueryDslRepository.java
@@ -3,7 +3,7 @@ package com.jangburich.domain.team.domain.repository;
 import com.jangburich.domain.team.dto.response.MyTeamDetailsResponse;
 
 public interface TeamQueryDslRepository {
-    MyTeamDetailsResponse findMyTeamDetailsAsMember(Long userId, Long teamId);
+    MyTeamDetailsResponse findMyTeamDetailsAsMember(Long userId, Long teamId, Long storeId);
 
-    MyTeamDetailsResponse findMyTeamDetailsAsLeader(Long userId, Long teamId);
+    MyTeamDetailsResponse findMyTeamDetailsAsLeader(Long userId, Long teamId, Long storeId);
 }

--- a/src/main/java/com/jangburich/domain/team/domain/repository/TeamQueryDslRepositoryImpl.java
+++ b/src/main/java/com/jangburich/domain/team/domain/repository/TeamQueryDslRepositoryImpl.java
@@ -40,7 +40,7 @@ public class TeamQueryDslRepositoryImpl implements TeamQueryDslRepository {
     LocalDateTime endOfDay = currentDate.plusDays(1).atStartOfDay().minusNanos(1);
 
     @Override
-    public MyTeamDetailsResponse findMyTeamDetailsAsMember(Long userId, Long teamId) {
+    public MyTeamDetailsResponse findMyTeamDetailsAsMember(Long userId, Long teamId, Long storeId) {
 
         List<PrepayedStore> prepayedStores = queryFactory
                 .select(new QPrepayedStore(
@@ -51,7 +51,7 @@ public class TeamQueryDslRepositoryImpl implements TeamQueryDslRepository {
                         Expressions.constant(false)
                 ))
                 .from(store)
-                .leftJoin(storeTeam).on(storeTeam.team.id.eq(teamId))
+                .leftJoin(storeTeam).on(storeTeam.team.id.eq(storeId))
                 .fetch();
 
         List<String> images = queryFactory
@@ -109,7 +109,7 @@ public class TeamQueryDslRepositoryImpl implements TeamQueryDslRepository {
     }
 
     @Override
-    public MyTeamDetailsResponse findMyTeamDetailsAsLeader(Long userId, Long teamId) {
+    public MyTeamDetailsResponse findMyTeamDetailsAsLeader(Long userId, Long teamId, Long storeId) {
 
         List<PrepayedStore> prepayedStores = queryFactory
                 .select(new QPrepayedStore(
@@ -120,7 +120,7 @@ public class TeamQueryDslRepositoryImpl implements TeamQueryDslRepository {
                         Expressions.constant(false)
                 ))
                 .from(store)
-                .leftJoin(storeTeam).on(storeTeam.team.id.eq(teamId))
+                .leftJoin(storeTeam).on(storeTeam.team.id.eq(storeId))
                 .fetch();
 
         List<String> images = queryFactory

--- a/src/main/java/com/jangburich/domain/team/presentation/TeamController.java
+++ b/src/main/java/com/jangburich/domain/team/presentation/TeamController.java
@@ -65,13 +65,14 @@ public class TeamController {
 	}
 
 	@Operation(summary = "그룹(팀) 상세 조회", description = "내가 속한 팀의 정보를 상세 조회합니다.")
-	@GetMapping("/{teamId}")
+	@GetMapping("/{teamId}/{storeId}")
 	public ResponseCustom<MyTeamDetailsResponse> getTeamDetailsById(
 		Authentication authentication,
-		@PathVariable Long teamId
+		@PathVariable Long teamId,
+		@PathVariable Long storeId
 	) {
 		return ResponseCustom.OK(
-			teamService.getTeamDetailsById(AuthenticationParser.parseUserId(authentication), teamId));
+			teamService.getTeamDetailsById(AuthenticationParser.parseUserId(authentication), teamId, storeId));
 	}
 
 	@Operation(summary = "그룹(팀) 멤버 전체 조회", description = "그룹(팀)에 소속된 모든 멤버를 조회합니다.")


### PR DESCRIPTION
* feat: 장바구니 추가 기능 구현

* feat: 장바구니 조회 기능 구현

* feat: 상품 주문과 식권 사용 기능 구현

* style: 포인트트랜잭션 레포지토리명 변경

* deploy: 재배포

* deploy: 재배포2

* deploy: 로그인 로직 수정에 따른 재배포

* deploy: 로그인 로직 수정에 따른 재배포2

* feat: 식권 사용 기능 구현

* feat: yml 수정 사항 반영

* feat: 식권 사용 로직 수정

* feat: 주문 로직 수정 완료

* fix: 장바구니에 아무것도 없을 때 주문 시 active 되는 현상 수정

* feat: 주문 완료 시 리턴 값 수정

* feat: 내 그룹 조회 기능 구현

* feat: 기본 프로필 이미지 url 추가

* feat: 그룹 멤버 전체 조회 기능 구현

* feat: 1인당 사용 가능 금액 설정 컬럼 추가

* feat: 내 지갑 조회 기능 구현

* feat: 선결제 기능 구현

* feat: 유저 홈 화면 조회 기능 구현

* feat: 그룹 상세 조회 기능 구현

* feat: 가게 상세 조회 쿼리 수정

* deploy: 변경사항 반영을 위한 커밋

* deploy: 수정 사항 반영 재배포

* deploy: rds 교체로 인한 재배포

* deploy: rds 교체로 인한 재배포2

* feat: 홈 화면 소속팀 조회 쿼리 제대로 안되던 현상 해결, 대표이미지 반환 추가

* feat: 그룹 상세 조회 응답 컬럼명 변경

* feat: memberLimit 컬럼 삭제

* feat: 선결제 시 기존 결제 내역과 멱등성 문제 해결

* fix: 팀 상세 조회 시 이미지 쿼리가 의미 없이 join 되던 쿼리 수정

* feat: 가게 검색 기능 대폭 수정

* feat: 프론트 요구사 반영

* feat: searchcondition 삭제

* feat: 팀타입 desription 리턴 하도록 수정

* feat: 카테고리별 팀 조회 시 팀 생성일 컬럼 추가

* feat: 매장찾기_상세 페이지 조회 기능 구현

* feat: 비밀 코드 조회 기능 엔드 포인트 수정

* fix: conflict fix

* hotfix: 서버 복구

* hotfix: 서버 복구2

* feat: Barobill api 연동

* fix: 홈 화면에 같은 데이터가 중복되는 현상 수정

* infra: ElastiCache 연결을 위한 docker-compose 설정

* infra: cicd script 수정

* infra: cicd script ec2 주소 설정

* infra: cicd script 수정2

* infra: cicd script 수정3

* infra: cicd script 수정4

* infra: cicd script 수정5

* infra: cicd script 수정6

* infra: cicd script 수정7

* infra: cicd script 수정7

* infra: cicd script 수정8

* infra: cicd script 수정9

* infra: cicd script 수정10

* infra: cicd script 수정11

* infra: cicd script 수정12

* infra: cicd script 수정13

* infra: cicd script 수정14

* infra: cicd script 수정15

* infra: cicd script 수정16

* infra: cicd script 수정17

* infra: cicd script 수정18

* infra: cicd script 수정19

* infra: cicd script 수정20

* infra: cicd script 수정21

* infra: cicd script 수정22

* fix: 보유금액이 선결제 금액보다 작을 경우 상태값 변경(200->400)

* feat: 홈화면 가게 별 선결제 디데이 추가, 쿼리문 조정

* feat: 주문하기 로직 정상화

* feat: 장바구니에 다른 가게 물건이 있는지 검증 구현

* feat: 장바구니 비우기 기능 구현

* deploy: cd retry

* feat: 매장 상세 페이지 조회 메뉴 정렬 조건 추가

* feat: 세금명세서 역발행 기능 추가

* feat: 거래 타입명 변경

* feat: pointTransaction 금액 음수(-) 표시 추가

* feat: 세금계산서 역발행 요청 기능 구현

* feat: 팀 조회 시 진행 상태값 반환 추가

* feat: 그룹 상세 조회 path storeId 추가

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
## 작업 내용
## 주의사항