### PR TITLE
feat: 그룹 조회 시 팀 id 조회 추가

### DIFF
--- a/src/main/java/com/jangburich/domain/team/application/TeamService.java
+++ b/src/main/java/com/jangburich/domain/team/application/TeamService.java
@@ -1,200 +1,201 @@
-package com.jangburich.domain.team.application;
+    package com.jangburich.domain.team.application;
 
-import com.jangburich.domain.store.domain.Store;
-import com.jangburich.domain.store.repository.StoreRepository;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+    import com.jangburich.domain.store.domain.Store;
+    import com.jangburich.domain.store.repository.StoreRepository;
+    import java.util.ArrayList;
+    import java.util.List;
+    import java.util.Optional;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+    import org.springframework.stereotype.Service;
+    import org.springframework.transaction.annotation.Transactional;
 
-import com.jangburich.domain.common.Status;
-import com.jangburich.domain.team.domain.Team;
-import com.jangburich.domain.team.domain.TeamLeader;
-import com.jangburich.domain.team.domain.TeamType;
-import com.jangburich.domain.team.domain.UserTeam;
-import com.jangburich.domain.team.domain.repository.TeamRepository;
-import com.jangburich.domain.team.domain.repository.UserTeamRepository;
-import com.jangburich.domain.team.dto.request.RegisterTeamRequest;
-import com.jangburich.domain.team.dto.response.MyTeamDetailsResponse;
-import com.jangburich.domain.team.dto.response.MyTeamResponse;
-import com.jangburich.domain.team.dto.response.TeamCodeResponse;
-import com.jangburich.domain.team.dto.response.TeamMemberResponse;
-import com.jangburich.domain.team.dto.response.TeamSecretCodeResponse;
-import com.jangburich.domain.user.domain.User;
-import com.jangburich.domain.user.repository.UserRepository;
-import com.jangburich.global.payload.Message;
+    import com.jangburich.domain.common.Status;
+    import com.jangburich.domain.team.domain.Team;
+    import com.jangburich.domain.team.domain.TeamLeader;
+    import com.jangburich.domain.team.domain.TeamType;
+    import com.jangburich.domain.team.domain.UserTeam;
+    import com.jangburich.domain.team.domain.repository.TeamRepository;
+    import com.jangburich.domain.team.domain.repository.UserTeamRepository;
+    import com.jangburich.domain.team.dto.request.RegisterTeamRequest;
+    import com.jangburich.domain.team.dto.response.MyTeamDetailsResponse;
+    import com.jangburich.domain.team.dto.response.MyTeamResponse;
+    import com.jangburich.domain.team.dto.response.TeamCodeResponse;
+    import com.jangburich.domain.team.dto.response.TeamMemberResponse;
+    import com.jangburich.domain.team.dto.response.TeamSecretCodeResponse;
+    import com.jangburich.domain.user.domain.User;
+    import com.jangburich.domain.user.repository.UserRepository;
+    import com.jangburich.global.payload.Message;
 
-import lombok.RequiredArgsConstructor;
+    import lombok.RequiredArgsConstructor;
 
-@Service
-@Transactional(readOnly = true)
-@RequiredArgsConstructor
-public class TeamService {
+    @Service
+    @Transactional(readOnly = true)
+    @RequiredArgsConstructor
+    public class TeamService {
 
-	private static final int ZERO = 0;
-	private static final String DEFAULT_PROFILE_IMAGE_URL = "https://github.com/user-attachments/assets/56565343-51f4-48b5-bf87-7585011d8de6";
+        private static final int ZERO = 0;
+        private static final String DEFAULT_PROFILE_IMAGE_URL = "https://github.com/user-attachments/assets/56565343-51f4-48b5-bf87-7585011d8de6";
 
-	private final TeamRepository teamRepository;
-	private final UserRepository userRepository;
-	private final UserTeamRepository userTeamRepository;
-	private final StoreRepository storeRepository;
+        private final TeamRepository teamRepository;
+        private final UserRepository userRepository;
+        private final UserTeamRepository userTeamRepository;
+        private final StoreRepository storeRepository;
 
-	@Transactional
-	public TeamSecretCodeResponse registerTeam(String userId, RegisterTeamRequest registerTeamRequest) {
-		User user = userRepository.findByProviderId(userId)
-			.orElseThrow(() -> new NullPointerException());
+        @Transactional
+        public TeamSecretCodeResponse registerTeam(String userId, RegisterTeamRequest registerTeamRequest) {
+            User user = userRepository.findByProviderId(userId)
+                    .orElseThrow(() -> new NullPointerException());
 
-		Team team = Team.builder()
-			.name(registerTeamRequest.teamName())
-			.description(registerTeamRequest.description())
-			.teamLeader(new TeamLeader(user.getUserId(), registerTeamRequest.teamLeaderAccountNumber(),
-				registerTeamRequest.bankName()))
-			.point(ZERO)
-			.teamType(TeamType.valueOf(registerTeamRequest.teamType()))
-			.build();
+            Team team = Team.builder()
+                    .name(registerTeamRequest.teamName())
+                    .description(registerTeamRequest.description())
+                    .teamLeader(new TeamLeader(user.getUserId(), registerTeamRequest.teamLeaderAccountNumber(),
+                            registerTeamRequest.bankName()))
+                    .point(ZERO)
+                    .teamType(TeamType.valueOf(registerTeamRequest.teamType()))
+                    .build();
 
-		Team saved = teamRepository.save(team);
+            Team saved = teamRepository.save(team);
 
-		UserTeam userTeam = UserTeam.of(user, team);
-		userTeamRepository.save(userTeam);
+            UserTeam userTeam = UserTeam.of(user, team);
+            userTeamRepository.save(userTeam);
 
-		TeamSecretCodeResponse teamSecretCodeResponse = new TeamSecretCodeResponse();
-		teamSecretCodeResponse.setUuid(saved.getSecretCode());
+            TeamSecretCodeResponse teamSecretCodeResponse = new TeamSecretCodeResponse();
+            teamSecretCodeResponse.setUuid(saved.getSecretCode());
 
-		return teamSecretCodeResponse;
-	}
+            return teamSecretCodeResponse;
+        }
 
-	@Transactional
-	public Message joinTeam(String userId, String joinCode) {
-		User user = userRepository.findByProviderId(userId)
-			.orElseThrow(() -> new NullPointerException());
+        @Transactional
+        public Message joinTeam(String userId, String joinCode) {
+            User user = userRepository.findByProviderId(userId)
+                    .orElseThrow(() -> new NullPointerException());
 
-		Team team = teamRepository.findBySecretCode(joinCode)
-			.orElseThrow(() -> new IllegalArgumentException("Team not found"));
+            Team team = teamRepository.findBySecretCode(joinCode)
+                    .orElseThrow(() -> new IllegalArgumentException("Team not found"));
 
-		team.validateJoinCode(joinCode);
+            team.validateJoinCode(joinCode);
 
-		int currentMemberCount = userTeamRepository.countByTeam(team);
+            int currentMemberCount = userTeamRepository.countByTeam(team);
 
-		if (userTeamRepository.existsByUserAndTeam(user, team)) {
-			throw new IllegalStateException("유저는 이미 해당 팀에 속해 있습니다.");
-		}
+            if (userTeamRepository.existsByUserAndTeam(user, team)) {
+                throw new IllegalStateException("유저는 이미 해당 팀에 속해 있습니다.");
+            }
 
-		UserTeam userTeam = UserTeam.of(user, team);
-		userTeamRepository.save(userTeam);
+            UserTeam userTeam = UserTeam.of(user, team);
+            userTeamRepository.save(userTeam);
 
-		return Message.builder()
-			.message("팀에 성공적으로 참여하였습니다.")
-			.build();
-	}
+            return Message.builder()
+                    .message("팀에 성공적으로 참여하였습니다.")
+                    .build();
+        }
 
-	public List<MyTeamResponse> getMyTeamByCategory(String userId, String category) {
-		User user = userRepository.findByProviderId(userId)
-			.orElseThrow(() -> new NullPointerException("사용자를 찾을 수 없습니다."));
+        public List<MyTeamResponse> getMyTeamByCategory(String userId, String category) {
+            User user = userRepository.findByProviderId(userId)
+                    .orElseThrow(() -> new NullPointerException("사용자를 찾을 수 없습니다."));
 
-		List<Team> teams = teamRepository.findAllByUserAndStatus(user, Status.ACTIVE)
-			.orElseThrow(() -> new IllegalArgumentException("해당하는 팀을 찾을 수 없습니다."));
+            List<Team> teams = teamRepository.findAllByUserAndStatus(user, Status.ACTIVE)
+                    .orElseThrow(() -> new IllegalArgumentException("해당하는 팀을 찾을 수 없습니다."));
 
-		List<MyTeamResponse> myTeamResponses = new ArrayList<>();
+            List<MyTeamResponse> myTeamResponses = new ArrayList<>();
 
-		for (Team team : teams) {
-			boolean isMeLeader = team.getTeamLeader().getUser_id().equals(user.getUserId());
+            for (Team team : teams) {
+                boolean isMeLeader = team.getTeamLeader().getUser_id().equals(user.getUserId());
 
-			int peopleCount = userTeamRepository.countByTeam(team);
+                int peopleCount = userTeamRepository.countByTeam(team);
 
-			List<String> profileImageUrls = userTeamRepository.findAllByTeam(team).stream()
-				.map(userTeam -> Optional.ofNullable(userTeam.getUser().getProfileImageUrl())
-					.orElse(DEFAULT_PROFILE_IMAGE_URL))
-				.toList();
+                List<String> profileImageUrls = userTeamRepository.findAllByTeam(team).stream()
+                        .map(userTeam -> Optional.ofNullable(userTeam.getUser().getProfileImageUrl())
+                                .orElse(DEFAULT_PROFILE_IMAGE_URL))
+                        .toList();
 
-			if ("ALL".equalsIgnoreCase(category) ||
-				("LEADER".equalsIgnoreCase(category) && isMeLeader) ||
-				("MEMBER".equalsIgnoreCase(category) && !isMeLeader)) {
+                if ("ALL".equalsIgnoreCase(category) ||
+                        ("LEADER".equalsIgnoreCase(category) && isMeLeader) ||
+                        ("MEMBER".equalsIgnoreCase(category) && !isMeLeader)) {
 
-				MyTeamResponse response = new MyTeamResponse(
-					team.getName(),
-					"진행중",
-					team.getCreatedAt().toLocalDate(),
-					team.getTeamType().getDescription(),
-					false, // isLiked는 임의로 false로 설정
-					peopleCount,
-					isMeLeader,
-					profileImageUrls
-				);
-				myTeamResponses.add(response);
-			}
-		}
+                    MyTeamResponse response = new MyTeamResponse(
+                            team.getId(),
+                            team.getName(),
+                            "진행중",
+                            team.getCreatedAt().toLocalDate(),
+                            team.getTeamType().getDescription(),
+                            false, // isLiked는 임의로 false로 설정
+                            peopleCount,
+                            isMeLeader,
+                            profileImageUrls
+                    );
+                    myTeamResponses.add(response);
+                }
+            }
 
-		return myTeamResponses;
-	}
+            return myTeamResponses;
+        }
 
-	public MyTeamDetailsResponse getTeamDetailsById(String userId, Long teamId, Long storeId) {
-		User user = userRepository.findByProviderId(userId)
-			.orElseThrow(() -> new NullPointerException("사용자를 찾을 수 없습니다."));
+        public MyTeamDetailsResponse getTeamDetailsById(String userId, Long teamId, Long storeId) {
+            User user = userRepository.findByProviderId(userId)
+                    .orElseThrow(() -> new NullPointerException("사용자를 찾을 수 없습니다."));
 
-		Team team = teamRepository.findById(teamId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 팀을 찾을 수 없습니다."));
+            Team team = teamRepository.findById(teamId)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 팀을 찾을 수 없습니다."));
 
-		Store store = storeRepository.findById(storeId)
-				.orElseThrow(() -> new IllegalArgumentException("해당 가게를 찾을 수 없습니다."));
+            Store store = storeRepository.findById(storeId)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 가게를 찾을 수 없습니다."));
 
-		if (!team.getTeamLeader().getUser_id().equals(user.getUserId())) {
-			// 일반 구성원
-			return teamRepository.findMyTeamDetailsAsMember(user.getUserId(),
-				teamId, storeId);
-		}
-		// 팀 리더일 때
+            if (!team.getTeamLeader().getUser_id().equals(user.getUserId())) {
+                // 일반 구성원
+                return teamRepository.findMyTeamDetailsAsMember(user.getUserId(),
+                        teamId, storeId);
+            }
+            // 팀 리더일 때
 
-		return teamRepository.findMyTeamDetailsAsLeader(user.getUserId(),
-			teamId, storeId);
-	}
+            return teamRepository.findMyTeamDetailsAsLeader(user.getUserId(),
+                    teamId, storeId);
+        }
 
-	public List<TeamMemberResponse> getTeamMembers(String userId, Long teamId) {
-		User user = userRepository.findByProviderId(userId)
-			.orElseThrow(() -> new NullPointerException("사용자를 찾을 수 없습니다."));
+        public List<TeamMemberResponse> getTeamMembers(String userId, Long teamId) {
+            User user = userRepository.findByProviderId(userId)
+                    .orElseThrow(() -> new NullPointerException("사용자를 찾을 수 없습니다."));
 
-		Team team = teamRepository.findById(teamId)
-			.orElseThrow(() -> new IllegalArgumentException("해당하는 팀을 찾을 수 없습니다."));
+            Team team = teamRepository.findById(teamId)
+                    .orElseThrow(() -> new IllegalArgumentException("해당하는 팀을 찾을 수 없습니다."));
 
-		List<UserTeam> userTeams = userTeamRepository.findAllByTeamAndStatus(team, Status.ACTIVE);
+            List<UserTeam> userTeams = userTeamRepository.findAllByTeamAndStatus(team, Status.ACTIVE);
 
-		return userTeams.stream()
-			.map(userTeam -> {
-				User teamMember = userTeam.getUser();
+            return userTeams.stream()
+                    .map(userTeam -> {
+                        User teamMember = userTeam.getUser();
 
-				return new TeamMemberResponse(
-					teamMember.getUserId(),
-					teamMember.getName(),
-					teamMember.getUserId().equals(user.getUserId()),
-					team.getTeamLeader().getUser_id().equals(teamMember.getUserId()),
-					Optional.ofNullable(teamMember.getProfileImageUrl()).orElse(DEFAULT_PROFILE_IMAGE_URL)
-				);
-			})
-			.toList();
-	}
+                        return new TeamMemberResponse(
+                                teamMember.getUserId(),
+                                teamMember.getName(),
+                                teamMember.getUserId().equals(user.getUserId()),
+                                team.getTeamLeader().getUser_id().equals(teamMember.getUserId()),
+                                Optional.ofNullable(teamMember.getProfileImageUrl()).orElse(DEFAULT_PROFILE_IMAGE_URL)
+                        );
+                    })
+                    .toList();
+        }
 
-	public TeamCodeResponse getTeamsWithSecretCode(String secretCode) {
-		Team team = teamRepository.findBySecretCode(secretCode)
-			.orElseThrow(() -> new RuntimeException("시크릿 코드가 존재하지 않습니다."));
+        public TeamCodeResponse getTeamsWithSecretCode(String secretCode) {
+            Team team = teamRepository.findBySecretCode(secretCode)
+                    .orElseThrow(() -> new RuntimeException("시크릿 코드가 존재하지 않습니다."));
 
-		long count = userTeamRepository.findAllByTeam(team).size();
+            long count = userTeamRepository.findAllByTeam(team).size();
 
-		List<String> profileImages = userTeamRepository.findAllByTeam(team)
-			.stream()
-			.map(userTeam -> userTeam.getUser().getProfileImageUrl())
-			.limit(3)
-			.toList();
+            List<String> profileImages = userTeamRepository.findAllByTeam(team)
+                    .stream()
+                    .map(userTeam -> userTeam.getUser().getProfileImageUrl())
+                    .limit(3)
+                    .toList();
 
-		TeamCodeResponse teamCodeResponse = new TeamCodeResponse(
-			team.getName(),
-			team.getCreatedAt(),
-			team.getTeamType(),
-			count,
-			profileImages,
-			team.getStatus());
+            TeamCodeResponse teamCodeResponse = new TeamCodeResponse(
+                    team.getName(),
+                    team.getCreatedAt(),
+                    team.getTeamType(),
+                    count,
+                    profileImages,
+                    team.getStatus());
 
-		return teamCodeResponse;
-	}
-}
+            return teamCodeResponse;
+        }
+    }

--- a/src/main/java/com/jangburich/domain/team/dto/response/MyTeamResponse.java
+++ b/src/main/java/com/jangburich/domain/team/dto/response/MyTeamResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record MyTeamResponse(
+        Long teamId,
         String teamName,
         String processState,
         LocalDate createdDate,


### PR DESCRIPTION
* feat: 장바구니 추가 기능 구현

* feat: 장바구니 조회 기능 구현

* feat: 상품 주문과 식권 사용 기능 구현

* style: 포인트트랜잭션 레포지토리명 변경

* deploy: 재배포

* deploy: 재배포2

* deploy: 로그인 로직 수정에 따른 재배포

* deploy: 로그인 로직 수정에 따른 재배포2

* feat: 식권 사용 기능 구현

* feat: yml 수정 사항 반영

* feat: 식권 사용 로직 수정

* feat: 주문 로직 수정 완료

* fix: 장바구니에 아무것도 없을 때 주문 시 active 되는 현상 수정

* feat: 주문 완료 시 리턴 값 수정

* feat: 내 그룹 조회 기능 구현

* feat: 기본 프로필 이미지 url 추가

* feat: 그룹 멤버 전체 조회 기능 구현

* feat: 1인당 사용 가능 금액 설정 컬럼 추가

* feat: 내 지갑 조회 기능 구현

* feat: 선결제 기능 구현

* feat: 유저 홈 화면 조회 기능 구현

* feat: 그룹 상세 조회 기능 구현

* feat: 가게 상세 조회 쿼리 수정

* deploy: 변경사항 반영을 위한 커밋

* deploy: 수정 사항 반영 재배포

* deploy: rds 교체로 인한 재배포

* deploy: rds 교체로 인한 재배포2

* feat: 홈 화면 소속팀 조회 쿼리 제대로 안되던 현상 해결, 대표이미지 반환 추가

* feat: 그룹 상세 조회 응답 컬럼명 변경

* feat: memberLimit 컬럼 삭제

* feat: 선결제 시 기존 결제 내역과 멱등성 문제 해결

* fix: 팀 상세 조회 시 이미지 쿼리가 의미 없이 join 되던 쿼리 수정

* feat: 가게 검색 기능 대폭 수정

* feat: 프론트 요구사 반영

* feat: searchcondition 삭제

* feat: 팀타입 desription 리턴 하도록 수정

* feat: 카테고리별 팀 조회 시 팀 생성일 컬럼 추가

* feat: 매장찾기_상세 페이지 조회 기능 구현

* feat: 비밀 코드 조회 기능 엔드 포인트 수정

* fix: conflict fix

* hotfix: 서버 복구

* hotfix: 서버 복구2

* feat: Barobill api 연동

* fix: 홈 화면에 같은 데이터가 중복되는 현상 수정

* infra: ElastiCache 연결을 위한 docker-compose 설정

* infra: cicd script 수정

* infra: cicd script ec2 주소 설정

* infra: cicd script 수정2

* infra: cicd script 수정3

* infra: cicd script 수정4

* infra: cicd script 수정5

* infra: cicd script 수정6

* infra: cicd script 수정7

* infra: cicd script 수정7

* infra: cicd script 수정8

* infra: cicd script 수정9

* infra: cicd script 수정10

* infra: cicd script 수정11

* infra: cicd script 수정12

* infra: cicd script 수정13

* infra: cicd script 수정14

* infra: cicd script 수정15

* infra: cicd script 수정16

* infra: cicd script 수정17

* infra: cicd script 수정18

* infra: cicd script 수정19

* infra: cicd script 수정20

* infra: cicd script 수정21

* infra: cicd script 수정22

* fix: 보유금액이 선결제 금액보다 작을 경우 상태값 변경(200->400)

* feat: 홈화면 가게 별 선결제 디데이 추가, 쿼리문 조정

* feat: 주문하기 로직 정상화

* feat: 장바구니에 다른 가게 물건이 있는지 검증 구현

* feat: 장바구니 비우기 기능 구현

* deploy: cd retry

* feat: 매장 상세 페이지 조회 메뉴 정렬 조건 추가

* feat: 세금명세서 역발행 기능 추가

* feat: 거래 타입명 변경

* feat: pointTransaction 금액 음수(-) 표시 추가

* feat: 세금계산서 역발행 요청 기능 구현

* feat: 팀 조회 시 진행 상태값 반환 추가

* feat: 그룹 상세 조회 path storeId 추가

* feat: 그룹 조회 시 팀 id 조회 추가

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
## 작업 내용
## 주의사항